### PR TITLE
fix: collapse dropdown on increasing window size

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,13 +41,13 @@
           <nav class="nav">
               <ul class="menu_list">
                 <li>
-                  <a class="menu_link" href="#">community</a>
+                  <a class="menu_link" href="#">Community</a>
                 </li>
                 <li>
-                  <a class="menu_link" href="#projects">projects</a>
+                  <a class="menu_link" href="#projects">Projects</a>
                 </li>
                 <li>
-                  <a class="menu_link" href="#creators">creators</a>
+                  <a class="menu_link" href="#creators">Creators</a>
                 </li>
                 <li>
                   <a class="menu_link join-button" href="#join">Join us</a>
@@ -556,6 +556,13 @@
       })
       document.querySelector('.nav').addEventListener('click', (e) => {
         if (e.target.tagName === 'A') {
+          document.querySelector('.header_menu').classList.remove('open_header');
+          document.querySelector('.nav').classList.remove('open');
+          document.querySelector('.burger').classList.remove('active');
+        }
+      })
+      window.addEventListener('resize',()=>{
+        if(window.innerWidth>=767){
           document.querySelector('.header_menu').classList.remove('open_header');
           document.querySelector('.nav').classList.remove('open');
           document.querySelector('.burger').classList.remove('active');

--- a/main.css
+++ b/main.css
@@ -129,6 +129,9 @@ h3 {
 	padding-bottom: 235px;
 }
 
+.hidden{
+	display: none;
+}
 
 .logo img {
 	height: 30px;


### PR DESCRIPTION
## How does this PR impact the user?

<!-- Add "before" and "after" screenshots or screen recordings; we like loom for screen recordings https://www.loom.com/ -->
### Before:
A video of the bug is available in issue #38 

### After:

https://github.com/user-attachments/assets/3749ce4c-a2ef-4ba6-b1fd-cdf65cb2683f


## Description
> Fixes #38 
<!-- Concisely describe the changes in this PR -->
When the screen was originally small and the dropdown menu was open, if the user increased the window width, the dropdown wouldn't collapse, instead leaving behind an awkward background color. Fixed this by automatically collapsing the dropdown whenever window width is greater than 767px.

## Limitations

<!-- Anything related to this PR that wasn't "done" in this PR and why -->
None that come to mind.

## Checklist

- [x] my PR is focused and contains one wholistic change
- [ ] I have added screenshots or screen recordings to show the changes
