### PR TITLE
feat: add hide button for projects

### DIFF
--- a/app.js
+++ b/app.js
@@ -8,6 +8,20 @@ function loadMore() {
         hr[i].classList.add('sh');
       }
     document.getElementById('load-more-button').style.display = 'none';
+    document.getElementById('hide-button').style.display = 'block';
+}
+
+function hide() {
+    var paragraphs = document.querySelectorAll('#projects_items .load_more');
+    for (var i = 0; i < paragraphs.length; i++) {
+      paragraphs[i].classList.remove('show');
+    }
+    var hr = document.querySelectorAll('.line_hr');
+    for (var i = 0; i < hr.length; i++) {
+        hr[i].classList.remove('sh');
+      }
+    document.getElementById('load-more-button').style.display = 'block';
+    document.getElementById('hide-button').style.display = 'none';
 }
 
 async function getAuthors() {

--- a/app.js
+++ b/app.js
@@ -1,10 +1,10 @@
 function loadMore() {
-    var paragraphs = document.querySelectorAll('#projects_items .load_more');
-    for (var i = 0; i < paragraphs.length; i++) {
+    const paragraphs = document.querySelectorAll('#projects_items .load_more');
+    for (let i = 0; i < paragraphs.length; i++) {
       paragraphs[i].classList.add('show');
     }
-    var hr = document.querySelectorAll('.line_hr');
-    for (var i = 0; i < hr.length; i++) {
+    const hr = document.querySelectorAll('.line_hr');
+    for (let i = 0; i < hr.length; i++) {
         hr[i].classList.add('sh');
       }
     document.getElementById('load-more-button').style.display = 'none';
@@ -12,12 +12,12 @@ function loadMore() {
 }
 
 function hide() {
-    var paragraphs = document.querySelectorAll('#projects_items .load_more');
-    for (var i = 0; i < paragraphs.length; i++) {
+    const paragraphs = document.querySelectorAll('#projects_items .load_more');
+    for (let i = 0; i < paragraphs.length; i++) {
       paragraphs[i].classList.remove('show');
     }
-    var hr = document.querySelectorAll('.line_hr');
-    for (var i = 0; i < hr.length; i++) {
+    const hr = document.querySelectorAll('.line_hr');
+    for (let i = 0; i < hr.length; i++) {
         hr[i].classList.remove('sh');
       }
     document.getElementById('load-more-button').style.display = 'block';

--- a/index.html
+++ b/index.html
@@ -513,6 +513,7 @@
             </div>
 
             <button id="load-more-button" class="more_pr" onclick="loadMore()">Load More</button>
+            <button id="hide-button" class="more_pr" onclick="hide()">Hide</button>
           </div>
         </div>
       </section>

--- a/main.css
+++ b/main.css
@@ -338,10 +338,16 @@ hr {
 	font-size: 16px;
 	margin: auto;
 	margin-top: 30px;
+	cursor: pointer;
 }
 
 
 /*LOAD MORE*/
+#hide-button{
+	display: none;
+}
+
+
 #projects_items .load_more {
 	display: none;
 }


### PR DESCRIPTION
## How does this PR impact the user?
This PR is linked to issue #14 

### Before:
No option to hide expanded projects

![Screenshot 2024-10-02 144156](https://github.com/user-attachments/assets/be4a2272-f6cb-4955-a091-946b65d1eb16)


### After:
Added hide button with expanded projects

![Screenshot 2024-10-02 144218](https://github.com/user-attachments/assets/2a5982d4-411a-4c31-9317-36d922f43035)


## Description

Users are now able to hide projects previously expanded using "Load More" through the new "Hide" button. It hides the extra projects and brings back the "Load More" button. I have also changed the cursor type for both the buttons to "pointer" for better UX. 