### PR TITLE
 feat: Add links to Members' (Creators) GitHub profiles in the Creators section (#66)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "liveServer.settings.port": 5501
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "liveServer.settings.port": 5501
-}

--- a/app.js
+++ b/app.js
@@ -65,6 +65,7 @@ async function setAuthors(apiURL) {
     personDiv.innerHTML = `
                 <div class="name_and_img">
                     <img src="${author.avatar}" alt="${author.name}'s avatar">
+                     <a href="${contributor.html_url}" class="tooltip" target="_blank">
                     <p class="person_name">${author.name}</p>
                 </div>
                 <p class="about_person">${author.bio || 'No biography available'}</p>


### PR DESCRIPTION
Added clickable links to the GitHub profiles of  Creators in the Creators section. Ensures easy access to their profiles directly from the webpage.



